### PR TITLE
Add SVOTC integration scaffold (config flow, coordinator, entities)

### DIFF
--- a/custom_components/svotc/__init__.py
+++ b/custom_components/svotc/__init__.py
@@ -1,0 +1,29 @@
+"""SVOTC integration setup."""
+
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+from .coordinator import SVOTCCoordinator
+
+PLATFORMS: list[Platform] = [Platform.NUMBER, Platform.SELECT, Platform.SENSOR]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up SVOTC from a config entry."""
+    coordinator = SVOTCCoordinator(hass, entry)
+    await coordinator.async_config_entry_first_refresh()
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a SVOTC config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id, None)
+    return unload_ok

--- a/custom_components/svotc/config_flow.py
+++ b/custom_components/svotc/config_flow.py
@@ -1,0 +1,100 @@
+"""Config flow for SVOTC."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.helpers import selector
+
+from .const import (
+    CONF_INDOOR_TEMPERATURE,
+    CONF_OUTDOOR_TEMPERATURE,
+    CONF_PRICE_ENTITY,
+    CONF_WEATHER_ENTITY,
+    DOMAIN,
+)
+
+
+def _schema(defaults: dict[str, Any]) -> vol.Schema:
+    """Build the config schema with optional entity selectors."""
+    return vol.Schema(
+        {
+            vol.Optional(
+                CONF_INDOOR_TEMPERATURE,
+                default=defaults.get(CONF_INDOOR_TEMPERATURE),
+            ): selector.EntitySelector(
+                selector.EntitySelectorConfig(domain=["sensor"])
+            ),
+            vol.Optional(
+                CONF_OUTDOOR_TEMPERATURE,
+                default=defaults.get(CONF_OUTDOOR_TEMPERATURE),
+            ): selector.EntitySelector(
+                selector.EntitySelectorConfig(domain=["sensor"])
+            ),
+            vol.Optional(
+                CONF_PRICE_ENTITY,
+                default=defaults.get(CONF_PRICE_ENTITY),
+            ): selector.EntitySelector(
+                selector.EntitySelectorConfig(domain=["sensor"])
+            ),
+            vol.Optional(
+                CONF_WEATHER_ENTITY,
+                default=defaults.get(CONF_WEATHER_ENTITY),
+            ): selector.EntitySelector(
+                selector.EntitySelectorConfig(domain=["weather"])
+            ),
+        }
+    )
+
+
+def _clean_input(user_input: dict[str, Any]) -> dict[str, Any]:
+    """Remove empty values to allow auto-detection."""
+    return {key: value for key, value in user_input.items() if value not in ("", None)}
+
+
+class SVOTCConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for SVOTC."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.FlowResult:
+        """Handle the initial step."""
+        if user_input is not None:
+            data = _clean_input(user_input)
+            return self.async_create_entry(title="SVOTC", data=data)
+
+        return self.async_show_form(step_id="user", data_schema=_schema({}))
+
+    @staticmethod
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> config_entries.OptionsFlow:
+        """Return the options flow."""
+        return SVOTCOptionsFlow(config_entry)
+
+
+class SVOTCOptionsFlow(config_entries.OptionsFlow):
+    """Handle options flow for SVOTC."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize options flow."""
+        self._config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.FlowResult:
+        """Manage the options."""
+        if user_input is not None:
+            options = _clean_input(user_input)
+            return self.async_create_entry(title="", data=options)
+
+        defaults = {
+            **self._config_entry.data,
+            **self._config_entry.options,
+        }
+        return self.async_show_form(step_id="init", data_schema=_schema(defaults))

--- a/custom_components/svotc/const.py
+++ b/custom_components/svotc/const.py
@@ -1,0 +1,16 @@
+"""Constants for the SVOTC integration."""
+
+DOMAIN = "svotc"
+
+CONF_INDOOR_TEMPERATURE = "indoor_temperature"
+CONF_OUTDOOR_TEMPERATURE = "outdoor_temperature"
+CONF_PRICE_ENTITY = "price_entity"
+CONF_WEATHER_ENTITY = "weather_entity"
+
+DEFAULT_BRAKE_AGGRESSIVENESS = 0
+DEFAULT_HEAT_AGGRESSIVENESS = 0
+DEFAULT_COMFORT_TEMPERATURE = 21.0
+DEFAULT_VACATION_TEMPERATURE = 17.0
+DEFAULT_MODE = "Off"
+
+MODE_OPTIONS = ["Off", "Smart", "Vacation"]

--- a/custom_components/svotc/coordinator.py
+++ b/custom_components/svotc/coordinator.py
@@ -1,0 +1,92 @@
+"""Data coordinator for SVOTC."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import (
+    CONF_INDOOR_TEMPERATURE,
+    CONF_OUTDOOR_TEMPERATURE,
+    DEFAULT_BRAKE_AGGRESSIVENESS,
+    DEFAULT_COMFORT_TEMPERATURE,
+    DEFAULT_HEAT_AGGRESSIVENESS,
+    DEFAULT_MODE,
+    DEFAULT_VACATION_TEMPERATURE,
+    DOMAIN,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class SVOTCCoordinator(DataUpdateCoordinator[dict[str, object]]):
+    """Coordinate SVOTC state updates."""
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=timedelta(seconds=60),
+        )
+        self.entry = entry
+        self.values: dict[str, object] = {
+            "brake_aggressiveness": DEFAULT_BRAKE_AGGRESSIVENESS,
+            "heat_aggressiveness": DEFAULT_HEAT_AGGRESSIVENESS,
+            "comfort_temperature": DEFAULT_COMFORT_TEMPERATURE,
+            "vacation_temperature": DEFAULT_VACATION_TEMPERATURE,
+            "mode": DEFAULT_MODE,
+        }
+
+    def _read_temperature(self, entity_id: str | None) -> float | None:
+        """Read a temperature from a Home Assistant state."""
+        if not entity_id:
+            return None
+        state = self.hass.states.get(entity_id)
+        if state is None or state.state in ("unknown", "unavailable"):
+            return None
+        try:
+            return float(state.state)
+        except ValueError:
+            return None
+
+    async def async_set_value(self, key: str, value: object) -> None:
+        """Persist a value and refresh coordinator data."""
+        self.values[key] = value
+        await self.async_request_refresh()
+
+    async def _async_update_data(self) -> dict[str, object]:
+        """Fetch data for SVOTC sensors."""
+        entry_data = {**self.entry.data, **self.entry.options}
+        indoor_temp = self._read_temperature(entry_data.get(CONF_INDOOR_TEMPERATURE))
+        outdoor_temp = self._read_temperature(entry_data.get(CONF_OUTDOOR_TEMPERATURE))
+
+        offset = 0.0
+        virtual_outdoor = (
+            outdoor_temp + offset if outdoor_temp is not None else None
+        )
+        mode = self.values.get("mode", DEFAULT_MODE)
+
+        if mode == "Vacation":
+            dynamic_target = self.values.get(
+                "vacation_temperature", DEFAULT_VACATION_TEMPERATURE
+            )
+        else:
+            dynamic_target = self.values.get(
+                "comfort_temperature", DEFAULT_COMFORT_TEMPERATURE
+            )
+
+        return {
+            "indoor_temperature": indoor_temp,
+            "outdoor_temperature": outdoor_temp,
+            "virtual_outdoor_temperature": virtual_outdoor,
+            "offset": offset,
+            "dynamic_target_temperature": dynamic_target,
+            "status": "stub",
+            "reason_code": "not_implemented",
+        }

--- a/custom_components/svotc/manifest.json
+++ b/custom_components/svotc/manifest.json
@@ -1,0 +1,8 @@
+{
+  "domain": "svotc",
+  "name": "Smart Virtual Outdoor Temperature Control",
+  "version": "0.1.0",
+  "config_flow": true,
+  "documentation": "https://github.com/example/svotc",
+  "iot_class": "calculated"
+}

--- a/custom_components/svotc/number.py
+++ b/custom_components/svotc/number.py
@@ -1,0 +1,124 @@
+"""Number entities for SVOTC."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from homeassistant.components.number import NumberEntity, NumberEntityDescription, NumberMode
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
+
+from .const import (
+    DEFAULT_BRAKE_AGGRESSIVENESS,
+    DEFAULT_COMFORT_TEMPERATURE,
+    DEFAULT_HEAT_AGGRESSIVENESS,
+    DEFAULT_VACATION_TEMPERATURE,
+    DOMAIN,
+)
+from .coordinator import SVOTCCoordinator
+
+
+@dataclass(frozen=True, kw_only=True)
+class SVOTCNumberDescription(NumberEntityDescription):
+    """Describe a SVOTC number entity."""
+
+    key: str
+    default: float
+
+
+NUMBER_DESCRIPTIONS: tuple[SVOTCNumberDescription, ...] = (
+    SVOTCNumberDescription(
+        key="brake_aggressiveness",
+        translation_key="brake_aggressiveness",
+        default=DEFAULT_BRAKE_AGGRESSIVENESS,
+        native_min_value=0,
+        native_max_value=5,
+        native_step=1,
+    ),
+    SVOTCNumberDescription(
+        key="heat_aggressiveness",
+        translation_key="heat_aggressiveness",
+        default=DEFAULT_HEAT_AGGRESSIVENESS,
+        native_min_value=0,
+        native_max_value=5,
+        native_step=1,
+    ),
+    SVOTCNumberDescription(
+        key="comfort_temperature",
+        translation_key="comfort_temperature",
+        default=DEFAULT_COMFORT_TEMPERATURE,
+        native_min_value=5,
+        native_max_value=30,
+        native_step=0.5,
+    ),
+    SVOTCNumberDescription(
+        key="vacation_temperature",
+        translation_key="vacation_temperature",
+        default=DEFAULT_VACATION_TEMPERATURE,
+        native_min_value=5,
+        native_max_value=30,
+        native_step=0.5,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up SVOTC number entities."""
+    coordinator: SVOTCCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(
+        SVOTCNumberEntity(coordinator, entry, description)
+        for description in NUMBER_DESCRIPTIONS
+    )
+
+
+class SVOTCNumberEntity(NumberEntity, RestoreEntity):
+    """Representation of a SVOTC number entity."""
+
+    _attr_mode = NumberMode.BOX
+
+    def __init__(
+        self,
+        coordinator: SVOTCCoordinator,
+        entry: ConfigEntry,
+        description: SVOTCNumberDescription,
+    ) -> None:
+        """Initialize the SVOTC number entity."""
+        self.entity_description = description
+        self.coordinator = coordinator
+        self._attr_unique_id = f"{entry.entry_id}_{description.key}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.entry_id)},
+            name="SVOTC",
+        )
+
+    @property
+    def native_value(self) -> float:
+        """Return the current value."""
+        return float(
+            self.coordinator.values.get(
+                self.entity_description.key, self.entity_description.default
+            )
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Restore value on startup."""
+        await super().async_added_to_hass()
+        state = await self.async_get_last_state()
+        if state is None:
+            return
+        try:
+            restored = float(state.state)
+        except ValueError:
+            return
+        await self.coordinator.async_set_value(self.entity_description.key, restored)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Update the value."""
+        await self.coordinator.async_set_value(self.entity_description.key, value)

--- a/custom_components/svotc/select.py
+++ b/custom_components/svotc/select.py
@@ -1,0 +1,56 @@
+"""Select entity for SVOTC."""
+
+from __future__ import annotations
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
+
+from .const import DEFAULT_MODE, DOMAIN, MODE_OPTIONS
+from .coordinator import SVOTCCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up SVOTC select entities."""
+    coordinator: SVOTCCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([SVOTCModeSelect(coordinator, entry)])
+
+
+class SVOTCModeSelect(SelectEntity, RestoreEntity):
+    """Representation of the SVOTC mode select."""
+
+    _attr_options = MODE_OPTIONS
+    _attr_translation_key = "mode"
+
+    def __init__(self, coordinator: SVOTCCoordinator, entry: ConfigEntry) -> None:
+        """Initialize the mode select."""
+        self.coordinator = coordinator
+        self._attr_unique_id = f"{entry.entry_id}_mode"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.entry_id)},
+            name="SVOTC",
+        )
+
+    @property
+    def current_option(self) -> str:
+        """Return the current selected mode."""
+        return str(self.coordinator.values.get("mode", DEFAULT_MODE))
+
+    async def async_added_to_hass(self) -> None:
+        """Restore value on startup."""
+        await super().async_added_to_hass()
+        state = await self.async_get_last_state()
+        if state is None or state.state not in MODE_OPTIONS:
+            return
+        await self.coordinator.async_set_value("mode", state.state)
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+        await self.coordinator.async_set_value("mode", option)

--- a/custom_components/svotc/sensor.py
+++ b/custom_components/svotc/sensor.py
@@ -1,0 +1,87 @@
+"""Sensor entities for SVOTC."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import SVOTCCoordinator
+
+
+@dataclass(frozen=True, kw_only=True)
+class SVOTCSensorDescription(SensorEntityDescription):
+    """Describe a SVOTC sensor."""
+
+    key: str
+
+
+SENSOR_DESCRIPTIONS: tuple[SVOTCSensorDescription, ...] = (
+    SVOTCSensorDescription(
+        key="virtual_outdoor_temperature",
+        translation_key="virtual_outdoor_temperature",
+    ),
+    SVOTCSensorDescription(
+        key="offset",
+        translation_key="offset",
+    ),
+    SVOTCSensorDescription(
+        key="dynamic_target_temperature",
+        translation_key="dynamic_target_temperature",
+    ),
+    SVOTCSensorDescription(
+        key="status",
+        translation_key="status",
+    ),
+    SVOTCSensorDescription(
+        key="reason_code",
+        translation_key="reason_code",
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up SVOTC sensors."""
+    coordinator: SVOTCCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(
+        SVOTCSensorEntity(coordinator, entry, description)
+        for description in SENSOR_DESCRIPTIONS
+    )
+
+
+class SVOTCSensorEntity(SensorEntity):
+    """Representation of a SVOTC sensor."""
+
+    def __init__(
+        self,
+        coordinator: SVOTCCoordinator,
+        entry: ConfigEntry,
+        description: SVOTCSensorDescription,
+    ) -> None:
+        """Initialize the sensor."""
+        self.coordinator = coordinator
+        self.entity_description = description
+        self._attr_unique_id = f"{entry.entry_id}_{description.key}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.entry_id)},
+            name="SVOTC",
+        )
+
+    @property
+    def native_value(self) -> object:
+        """Return the sensor value."""
+        return self.coordinator.data.get(self.entity_description.key)
+
+    @property
+    def available(self) -> bool:
+        """Return entity availability."""
+        return self.coordinator.last_update_success

--- a/custom_components/svotc/strings.json
+++ b/custom_components/svotc/strings.json
@@ -1,0 +1,74 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "SVOTC setup",
+        "description": "Select optional entities or leave blank for auto-detect.",
+        "data": {
+          "indoor_temperature": "Indoor temperature sensor",
+          "outdoor_temperature": "Outdoor temperature sensor",
+          "price_entity": "Price sensor",
+          "weather_entity": "Weather entity"
+        }
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "SVOTC options",
+        "description": "Update optional entity selections or leave blank for auto-detect.",
+        "data": {
+          "indoor_temperature": "Indoor temperature sensor",
+          "outdoor_temperature": "Outdoor temperature sensor",
+          "price_entity": "Price sensor",
+          "weather_entity": "Weather entity"
+        }
+      }
+    }
+  },
+  "entity": {
+    "number": {
+      "svotc": {
+        "brake_aggressiveness": {
+          "name": "Brake aggressiveness"
+        },
+        "heat_aggressiveness": {
+          "name": "Heat aggressiveness"
+        },
+        "comfort_temperature": {
+          "name": "Comfort temperature"
+        },
+        "vacation_temperature": {
+          "name": "Vacation temperature"
+        }
+      }
+    },
+    "select": {
+      "svotc": {
+        "mode": {
+          "name": "Mode"
+        }
+      }
+    },
+    "sensor": {
+      "svotc": {
+        "virtual_outdoor_temperature": {
+          "name": "Virtual outdoor temperature"
+        },
+        "offset": {
+          "name": "Offset"
+        },
+        "dynamic_target_temperature": {
+          "name": "Dynamic target temperature"
+        },
+        "status": {
+          "name": "Status"
+        },
+        "reason_code": {
+          "name": "Reason code"
+        }
+      }
+    }
+  }
+}

--- a/custom_components/svotc/translations/en.json
+++ b/custom_components/svotc/translations/en.json
@@ -1,0 +1,74 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "SVOTC setup",
+        "description": "Select optional entities or leave blank for auto-detect.",
+        "data": {
+          "indoor_temperature": "Indoor temperature sensor",
+          "outdoor_temperature": "Outdoor temperature sensor",
+          "price_entity": "Price sensor",
+          "weather_entity": "Weather entity"
+        }
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "SVOTC options",
+        "description": "Update optional entity selections or leave blank for auto-detect.",
+        "data": {
+          "indoor_temperature": "Indoor temperature sensor",
+          "outdoor_temperature": "Outdoor temperature sensor",
+          "price_entity": "Price sensor",
+          "weather_entity": "Weather entity"
+        }
+      }
+    }
+  },
+  "entity": {
+    "number": {
+      "svotc": {
+        "brake_aggressiveness": {
+          "name": "Brake aggressiveness"
+        },
+        "heat_aggressiveness": {
+          "name": "Heat aggressiveness"
+        },
+        "comfort_temperature": {
+          "name": "Comfort temperature"
+        },
+        "vacation_temperature": {
+          "name": "Vacation temperature"
+        }
+      }
+    },
+    "select": {
+      "svotc": {
+        "mode": {
+          "name": "Mode"
+        }
+      }
+    },
+    "sensor": {
+      "svotc": {
+        "virtual_outdoor_temperature": {
+          "name": "Virtual outdoor temperature"
+        },
+        "offset": {
+          "name": "Offset"
+        },
+        "dynamic_target_temperature": {
+          "name": "Dynamic target temperature"
+        },
+        "status": {
+          "name": "Status"
+        },
+        "reason_code": {
+          "name": "Reason code"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- Introduce a minimal, drift-safe custom integration for Smart Virtual Outdoor Temperature Control (domain `svotc`) to own required entities and provide a config/options flow. 
- Provide a simple coordinator-driven architecture to enable future decision logic while keeping current behavior stubbed.

### Description
- Add integration manifest `custom_components/svotc/manifest.json` and constants in `const.py` including entity keys, defaults, and mode options. 
- Implement config flow and options flow in `config_flow.py` with optional entity selectors for indoor/outdoor temperature, price, and weather and support for leaving fields blank to allow auto-detect. 
- Add `SVOTCCoordinator` in `coordinator.py` using `DataUpdateCoordinator` with a 60s update interval and placeholder/stubbed decision logic that computes coordinator data keys used by sensors. 
- Create entity platform modules: `number.py` (numbers for brake/heat aggressiveness, comfort and vacation temperature with restore support), `select.py` (mode select with `Off/Smart/Vacation` and restore), and `sensor.py` (sensors for virtual outdoor temperature, offset, dynamic target temperature, status, and reason code), all wired to the coordinator. 
- Add English UI strings in `strings.json` and `translations/en.json` for config/options UI and entity names. 

### Testing
- Ran `python -m pytest`, which completed with no tests collected and reported "no tests ran".

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970daaceef8832e9ae1b541e2b0fd33)