### PR TITLE
Implement SVOTC decision logic modules and coordinator wiring

### DIFF
--- a/custom_components/svotc/coordinator.py
+++ b/custom_components/svotc/coordinator.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.util import dt as dt_util
 
 from .const import (
     CONF_INDOOR_TEMPERATURE,
@@ -18,9 +19,19 @@ from .const import (
     DEFAULT_MODE,
     DEFAULT_VACATION_TEMPERATURE,
     DOMAIN,
+    CONF_PRICE_ENTITY,
+    CONF_WEATHER_ENTITY,
 )
+from .decision import DecisionInput, decide
+from .forecast import min_outdoor_next_6h
+from .mapping import max_abs_offset
+from .prices import classify_price, extract_price_series
+from .ramp import max_delta_per_update, ramp_offset
 
 _LOGGER = logging.getLogger(__name__)
+
+_GRACE_PERIOD = timedelta(seconds=60)
+_GLITCH_HOLD = timedelta(seconds=60)
 
 
 class SVOTCCoordinator(DataUpdateCoordinator[dict[str, object]]):
@@ -42,6 +53,12 @@ class SVOTCCoordinator(DataUpdateCoordinator[dict[str, object]]):
             "vacation_temperature": DEFAULT_VACATION_TEMPERATURE,
             "mode": DEFAULT_MODE,
         }
+        self._start_time = dt_util.utcnow()
+        self._last_complete_time: datetime | None = None
+        self._last_output: dict[str, object] | None = None
+        self._last_offset: float = 0.0
+        self._last_price_state: str | None = None
+        self._last_price_state_changed: datetime | None = None
 
     def _read_temperature(self, entity_id: str | None) -> float | None:
         """Read a temperature from a Home Assistant state."""
@@ -55,6 +72,33 @@ class SVOTCCoordinator(DataUpdateCoordinator[dict[str, object]]):
         except ValueError:
             return None
 
+    def _read_state(self, entity_id: str | None) -> object | None:
+        """Read a raw state for an entity."""
+        if not entity_id:
+            return None
+        state = self.hass.states.get(entity_id)
+        if state is None or state.state in ("unknown", "unavailable"):
+            return None
+        return state
+
+    def _missing_reason(
+        self,
+        indoor: float | None,
+        outdoor: float | None,
+        price_available: bool,
+        forecast_available: bool,
+    ) -> str:
+        """Return a reason code for missing critical inputs."""
+        if indoor is None or outdoor is None:
+            return "MISSING_INDOOR"
+        if not price_available and not forecast_available:
+            return "MISSING_BOTH"
+        if not price_available:
+            return "MISSING_PRICE"
+        if not forecast_available:
+            return "MISSING_FORECAST"
+        return "MISSING_BOTH"
+
     async def async_set_value(self, key: str, value: object) -> None:
         """Persist a value and refresh coordinator data."""
         self.values[key] = value
@@ -62,14 +106,13 @@ class SVOTCCoordinator(DataUpdateCoordinator[dict[str, object]]):
 
     async def _async_update_data(self) -> dict[str, object]:
         """Fetch data for SVOTC sensors."""
+        now = dt_util.utcnow()
         entry_data = {**self.entry.data, **self.entry.options}
         indoor_temp = self._read_temperature(entry_data.get(CONF_INDOOR_TEMPERATURE))
         outdoor_temp = self._read_temperature(entry_data.get(CONF_OUTDOOR_TEMPERATURE))
+        price_state = self._read_state(entry_data.get(CONF_PRICE_ENTITY))
+        weather_state = self._read_state(entry_data.get(CONF_WEATHER_ENTITY))
 
-        offset = 0.0
-        virtual_outdoor = (
-            outdoor_temp + offset if outdoor_temp is not None else None
-        )
         mode = self.values.get("mode", DEFAULT_MODE)
 
         if mode == "Vacation":
@@ -81,12 +124,135 @@ class SVOTCCoordinator(DataUpdateCoordinator[dict[str, object]]):
                 "comfort_temperature", DEFAULT_COMFORT_TEMPERATURE
             )
 
-        return {
+        current_price, price_series = extract_price_series(price_state, now)
+        price_available = current_price is not None and len(price_series) > 0
+        price_class = classify_price(current_price, price_series)
+        forecast_min = min_outdoor_next_6h(weather_state, now)
+        forecast_available = forecast_min is not None
+
+        critical_missing = False
+        if entry_data.get(CONF_INDOOR_TEMPERATURE) and indoor_temp is None:
+            critical_missing = True
+        if entry_data.get(CONF_OUTDOOR_TEMPERATURE) and outdoor_temp is None:
+            critical_missing = True
+        if entry_data.get(CONF_PRICE_ENTITY) and not price_available:
+            critical_missing = True
+        if entry_data.get(CONF_WEATHER_ENTITY) and not forecast_available:
+            critical_missing = True
+
+        if not critical_missing:
+            self._last_complete_time = now
+
+        in_grace = now - self._start_time <= _GRACE_PERIOD
+        missing_duration = (
+            now - self._last_complete_time
+            if self._last_complete_time is not None
+            else None
+        )
+
+        if critical_missing and not in_grace and self._last_output is not None:
+            if missing_duration is not None and missing_duration <= _GLITCH_HOLD:
+                held = dict(self._last_output)
+                held["status"] = "Holding (sensor glitch)"
+                held["reason_code"] = "TEMP_GLITCH_HOLD"
+                return held
+
+        if critical_missing and not in_grace:
+            reason_code = self._missing_reason(
+                indoor_temp, outdoor_temp, price_available, forecast_available
+            )
+            status = reason_code.replace("_", " ").title()
+            if outdoor_temp is not None:
+                offset = 0.0
+                virtual_outdoor = outdoor_temp
+            elif self._last_output is not None:
+                offset = float(self._last_output.get("offset", 0.0))
+                virtual_outdoor = self._last_output.get(
+                    "virtual_outdoor_temperature"
+                )
+            else:
+                offset = 0.0
+                virtual_outdoor = None
+            result = {
+                "indoor_temperature": indoor_temp,
+                "outdoor_temperature": outdoor_temp,
+                "virtual_outdoor_temperature": virtual_outdoor,
+                "offset": offset,
+                "dynamic_target_temperature": dynamic_target,
+                "status": status,
+                "reason_code": reason_code,
+            }
+            self._last_output = result
+            self._last_offset = offset
+            return result
+
+        if in_grace and critical_missing:
+            offset = 0.0
+            virtual_outdoor = (
+                outdoor_temp + offset if outdoor_temp is not None else None
+            )
+            result = {
+                "indoor_temperature": indoor_temp,
+                "outdoor_temperature": outdoor_temp,
+                "virtual_outdoor_temperature": virtual_outdoor,
+                "offset": offset,
+                "dynamic_target_temperature": dynamic_target,
+                "status": "Startup grace",
+                "reason_code": "NEUTRAL",
+            }
+            self._last_output = result
+            self._last_offset = offset
+            return result
+
+        decision = decide(
+            DecisionInput(
+                mode=str(mode),
+                indoor_temp=indoor_temp,
+                outdoor_temp=outdoor_temp,
+                dynamic_target=float(dynamic_target),
+                brake_aggressiveness=int(
+                    self.values.get("brake_aggressiveness", DEFAULT_BRAKE_AGGRESSIVENESS)
+                ),
+                heat_aggressiveness=int(
+                    self.values.get("heat_aggressiveness", DEFAULT_HEAT_AGGRESSIVENESS)
+                ),
+                price_class=price_class,
+                forecast_min_next_6h=forecast_min,
+                price_available=price_available,
+                forecast_available=forecast_available,
+                now=now,
+                last_price_state=self._last_price_state,
+                last_price_state_changed=self._last_price_state_changed,
+            )
+        )
+
+        max_delta = max_delta_per_update(max_abs_offset())
+        offset = ramp_offset(self._last_offset, decision.target_offset, max_delta)
+        virtual_outdoor = (
+            outdoor_temp + offset if outdoor_temp is not None else None
+        )
+        if virtual_outdoor is not None:
+            clamped_virtual = max(-25.0, min(25.0, virtual_outdoor))
+            if clamped_virtual != virtual_outdoor:
+                offset = clamped_virtual - outdoor_temp
+                virtual_outdoor = clamped_virtual
+
+        if decision.price_state is not None:
+            if decision.price_state != self._last_price_state:
+                self._last_price_state = decision.price_state
+                self._last_price_state_changed = now
+
+        result = {
             "indoor_temperature": indoor_temp,
             "outdoor_temperature": outdoor_temp,
             "virtual_outdoor_temperature": virtual_outdoor,
             "offset": offset,
             "dynamic_target_temperature": dynamic_target,
-            "status": "stub",
-            "reason_code": "not_implemented",
+            "status": decision.status,
+            "reason_code": decision.reason_code,
+        }
+        self._last_output = result
+        self._last_offset = offset
+        return {
+            **result,
         }

--- a/custom_components/svotc/decision.py
+++ b/custom_components/svotc/decision.py
@@ -1,0 +1,174 @@
+"""Decision logic for SVOTC."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+from .mapping import brake_offset, heat_offset
+
+_DWELL_TIME = timedelta(minutes=30)
+
+_STATUS_BY_REASON = {
+    "SMART_FULL": "Smart (price + forecast)",
+    "SMART_PRICE_ONLY": "Smart (price only)",
+    "MISSING_FORECAST": "Missing forecast",
+    "MISSING_PRICE": "Missing price",
+    "MISSING_BOTH": "Missing price and forecast",
+    "MISSING_INDOOR": "Missing indoor temperature",
+    "OFF": "Off",
+    "FORECAST_HEAT_NEED": "Boosting (cold forecast ahead)",
+    "PRICE_BRAKE": "Braking (expensive price)",
+    "PRICE_BOOST": "Boosting (cheap price)",
+    "SAFETY_ANCHOR": "Safety anchor",
+    "NEUTRAL": "Neutral",
+    "TEMP_GLITCH_HOLD": "Holding (sensor glitch)",
+}
+
+
+@dataclass(frozen=True)
+class DecisionInput:
+    """Inputs required for the decision logic."""
+
+    mode: str
+    indoor_temp: float | None
+    outdoor_temp: float | None
+    dynamic_target: float
+    brake_aggressiveness: int
+    heat_aggressiveness: int
+    price_class: str | None
+    forecast_min_next_6h: float | None
+    price_available: bool
+    forecast_available: bool
+    now: datetime
+    last_price_state: str | None
+    last_price_state_changed: datetime | None
+
+
+@dataclass(frozen=True)
+class DecisionOutput:
+    """Decision output values."""
+
+    target_offset: float
+    reason_code: str
+    status: str
+    price_state: str | None
+
+
+def _status_for_reason(reason: str) -> str:
+    """Return a status string for a reason code."""
+    return _STATUS_BY_REASON.get(reason, reason)
+
+
+def _availability_code(price_available: bool, forecast_available: bool) -> str:
+    """Return the availability code for price/forecast inputs."""
+    if price_available and forecast_available:
+        return "SMART_FULL"
+    if price_available:
+        return "SMART_PRICE_ONLY"
+    if forecast_available:
+        return "MISSING_PRICE"
+    return "MISSING_BOTH"
+
+
+def _apply_price_dwell(
+    new_state: str,
+    last_state: str | None,
+    last_changed: datetime | None,
+    now: datetime,
+) -> str:
+    """Apply dwell time for price-driven state changes."""
+    if last_state is None or last_state == new_state:
+        return new_state
+    if last_changed is None:
+        return new_state
+    if now - last_changed < _DWELL_TIME:
+        return last_state
+    return new_state
+
+
+def decide(inputs: DecisionInput) -> DecisionOutput:
+    """Return the decision for the current update cycle."""
+    if inputs.mode == "Off":
+        return DecisionOutput(0.0, "OFF", _status_for_reason("OFF"), None)
+
+    if inputs.indoor_temp is None:
+        return DecisionOutput(
+            0.0, "MISSING_INDOOR", _status_for_reason("MISSING_INDOOR"), None
+        )
+
+    availability = _availability_code(
+        inputs.price_available, inputs.forecast_available
+    )
+
+    safety_needed = inputs.indoor_temp < inputs.dynamic_target
+    if safety_needed:
+        return DecisionOutput(
+            heat_offset(inputs.heat_aggressiveness),
+            "SAFETY_ANCHOR",
+            _status_for_reason("SAFETY_ANCHOR"),
+            None,
+        )
+
+    if availability in ("MISSING_PRICE", "MISSING_BOTH"):
+        return DecisionOutput(
+            0.0,
+            availability,
+            _status_for_reason(availability),
+            None,
+        )
+
+    price_state: str | None = None
+    target_offset = 0.0
+    reason_code = availability
+    status = _status_for_reason(availability)
+
+    if inputs.price_class == "expensive":
+        target_offset = brake_offset(inputs.brake_aggressiveness)
+        reason_code = "PRICE_BRAKE"
+        price_state = "brake"
+    elif inputs.price_class == "cheap":
+        target_offset = heat_offset(inputs.heat_aggressiveness)
+        reason_code = "PRICE_BOOST"
+        price_state = "boost"
+    elif inputs.price_class == "neutral":
+        target_offset = 0.0
+        reason_code = "NEUTRAL"
+        price_state = "neutral"
+
+    if (
+        inputs.forecast_available
+        and inputs.price_class == "neutral"
+        and inputs.outdoor_temp is not None
+        and inputs.forecast_min_next_6h is not None
+        and inputs.indoor_temp < inputs.dynamic_target + 0.2
+        and inputs.forecast_min_next_6h < inputs.outdoor_temp - 2.0
+    ):
+        return DecisionOutput(
+            heat_offset(inputs.heat_aggressiveness),
+            "FORECAST_HEAT_NEED",
+            _status_for_reason("FORECAST_HEAT_NEED"),
+            None,
+        )
+
+    if price_state is not None:
+        applied_state = _apply_price_dwell(
+            price_state,
+            inputs.last_price_state,
+            inputs.last_price_state_changed,
+            inputs.now,
+        )
+        if applied_state != price_state:
+            price_state = applied_state
+            if applied_state == "brake":
+                target_offset = brake_offset(inputs.brake_aggressiveness)
+                reason_code = "PRICE_BRAKE"
+            elif applied_state == "boost":
+                target_offset = heat_offset(inputs.heat_aggressiveness)
+                reason_code = "PRICE_BOOST"
+            else:
+                target_offset = 0.0
+                reason_code = "NEUTRAL"
+
+    status = _status_for_reason(reason_code)
+    return DecisionOutput(target_offset, reason_code, status, price_state)

--- a/custom_components/svotc/forecast.py
+++ b/custom_components/svotc/forecast.py
@@ -1,0 +1,54 @@
+"""Forecast helpers for SVOTC."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any
+
+from homeassistant.core import State
+from homeassistant.util import dt as dt_util
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    """Parse forecast datetime values."""
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        return dt_util.parse_datetime(value)
+    return None
+
+
+def min_outdoor_next_6h(state: State | None, now: datetime) -> float | None:
+    """Return the minimum forecast temperature for the next 6 hours."""
+    if state is None:
+        return None
+    forecast = state.attributes.get("forecast")
+    if not isinstance(forecast, list):
+        return None
+
+    window_end = now + timedelta(hours=6)
+    temps: list[float] = []
+    for entry in forecast:
+        if not isinstance(entry, dict):
+            continue
+        entry_time = _parse_datetime(entry.get("datetime"))
+        if entry_time is not None:
+            if entry_time < now or entry_time > window_end:
+                continue
+        try:
+            temps.append(float(entry.get("temperature")))
+        except (TypeError, ValueError):
+            continue
+
+    if not temps:
+        for entry in forecast[:6]:
+            if not isinstance(entry, dict):
+                continue
+            try:
+                temps.append(float(entry.get("temperature")))
+            except (TypeError, ValueError):
+                continue
+
+    if not temps:
+        return None
+    return min(temps)

--- a/custom_components/svotc/mapping.py
+++ b/custom_components/svotc/mapping.py
@@ -1,0 +1,26 @@
+"""Mapping helpers for aggressiveness to offsets."""
+
+from __future__ import annotations
+
+BRAKE_OFFSETS: list[float] = [0, 3, 5, 7, 9, 10]
+HEAT_OFFSETS: list[float] = [0, -1, -2, -3, -4, -5]
+
+
+def _clamp_level(level: int) -> int:
+    """Clamp aggressiveness to the supported range."""
+    return max(0, min(5, level))
+
+
+def brake_offset(level: int) -> float:
+    """Return the brake offset for a given aggressiveness."""
+    return float(BRAKE_OFFSETS[_clamp_level(level)])
+
+
+def heat_offset(level: int) -> float:
+    """Return the heat offset for a given aggressiveness."""
+    return float(HEAT_OFFSETS[_clamp_level(level)])
+
+
+def max_abs_offset() -> float:
+    """Return the maximum absolute offset used for ramping."""
+    return max(abs(max(BRAKE_OFFSETS)), abs(min(HEAT_OFFSETS)))

--- a/custom_components/svotc/prices.py
+++ b/custom_components/svotc/prices.py
@@ -1,0 +1,102 @@
+"""Helpers for price classification."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import datetime
+from typing import Any
+
+from homeassistant.core import State
+from homeassistant.util import dt as dt_util
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    """Parse a datetime value if possible."""
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        return dt_util.parse_datetime(value)
+    return None
+
+
+def _extract_price_values(entries: Iterable[Any], now: datetime) -> list[float]:
+    """Extract price values from iterable entries."""
+    values: list[float] = []
+    for entry in entries:
+        if isinstance(entry, dict):
+            if "start" in entry or "startsAt" in entry or "datetime" in entry:
+                start = (
+                    entry.get("start")
+                    or entry.get("startsAt")
+                    or entry.get("datetime")
+                )
+                parsed = _parse_datetime(start)
+                if parsed is not None and parsed < now:
+                    continue
+            for key in ("value", "price", "total", "energy"):
+                if key in entry:
+                    try:
+                        values.append(float(entry[key]))
+                    except (TypeError, ValueError):
+                        pass
+                    break
+        else:
+            try:
+                values.append(float(entry))
+            except (TypeError, ValueError):
+                continue
+    return values
+
+
+def extract_price_series(
+    state: State | None, now: datetime
+) -> tuple[float | None, list[float]]:
+    """Extract current price and a price series from an entity."""
+    if state is None or state.state in ("unknown", "unavailable"):
+        return None, []
+    try:
+        current_price = float(state.state)
+    except ValueError:
+        current_price = None
+
+    attributes = state.attributes
+    series: list[float] = []
+    for key in ("raw_today", "raw_tomorrow", "today", "tomorrow", "prices"):
+        data = attributes.get(key)
+        if isinstance(data, list):
+            series.extend(_extract_price_values(data, now))
+
+    if not series and current_price is not None:
+        series = [current_price]
+
+    return current_price, series
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    """Compute a percentile value for a list."""
+    if not values:
+        raise ValueError("Values required for percentile calculation")
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * percentile
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    if upper == lower:
+        return ordered[lower]
+    weight = position - lower
+    return ordered[lower] * (1 - weight) + ordered[upper] * weight
+
+
+def classify_price(current_price: float | None, prices: list[float]) -> str | None:
+    """Classify the current price as cheap, neutral, or expensive."""
+    if current_price is None or not prices:
+        return None
+    try:
+        p30 = _percentile(prices, 0.30)
+        p70 = _percentile(prices, 0.70)
+    except ValueError:
+        return None
+    if current_price <= p30:
+        return "cheap"
+    if current_price >= p70:
+        return "expensive"
+    return "neutral"

--- a/custom_components/svotc/ramp.py
+++ b/custom_components/svotc/ramp.py
@@ -1,0 +1,21 @@
+"""Offset ramping helpers."""
+
+from __future__ import annotations
+
+import math
+
+
+def max_delta_per_update(
+    max_offset: float, update_interval_s: int = 60, ramp_minutes: int = 20
+) -> float:
+    """Return the maximum offset delta per update."""
+    steps = max(1, int((ramp_minutes * 60) / update_interval_s))
+    return max_offset / steps
+
+
+def ramp_offset(current: float, target: float, max_delta: float) -> float:
+    """Limit offset changes to the configured ramp rate."""
+    delta = target - current
+    if abs(delta) <= max_delta:
+        return target
+    return current + math.copysign(max_delta, delta)


### PR DESCRIPTION
### Motivation
- Implement the SVOTC decision and helper modules to realize the price/forecast/safety policy and produce a virtual outdoor temperature according to spec.
- Add ramping, glitch handling, startup grace, clamping and anti-oscillation dwell behavior so the coordinator can safely drive heating curves without new user-facing features.

### Description
- Added decision logic in `custom_components/svotc/decision.py` implementing availability matrix, price percentile behaviour, forecast override (`FORECAST_HEAT_NEED`), safety anchor, reason codes/status and 30 min dwell for price-driven changes.
- Added helpers: `mapping.py` (brake/heat offsets and max offset), `prices.py` (extract price series and P30/P70 classifier), `forecast.py` (min forecast temperature for next 6h) and `ramp.py` (per-update max delta and ramping over 20 minutes).
- Wired the modules into `coordinator.py` to: read price/forecast entities, perform graceful startup (`_GRACE_PERIOD = 60s`), hold last output for short glitches (`_GLITCH_HOLD = 60s`), compute decision, apply ramping and clamp virtual outdoor to `-25..+25 °C`, and expose `status`/`reason_code` and `offset`/`virtual_outdoor_temperature` sensor values.
- Implemented mapping tables per spec (`BRAKE_OFFSETS = [0,3,5,7,9,10]`, `HEAT_OFFSETS = [0,-1,-2,-3,-4,-5]`) and derived per-update `max_delta` from `max_abs_offset()`.

### Testing
- Ran `pytest` in repository; no tests were discovered or executed and the suite reports no collected tests (no automated tests present).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970ddbfee08832eac1da7889d4cdc3f)