### PR TITLE
Update SVOTC friendly names

### DIFF
--- a/custom_components/svotc/strings.json
+++ b/custom_components/svotc/strings.json
@@ -31,30 +31,30 @@
     "number": {
       "svotc": {
         "brake_aggressiveness": {
-          "name": "Brake aggressiveness"
+          "name": "SVOTC Brake"
         },
         "heat_aggressiveness": {
-          "name": "Heat aggressiveness"
+          "name": "SVOTC Heat"
         },
         "comfort_temperature": {
-          "name": "Comfort temperature"
+          "name": "SVOTC Comfort"
         },
         "vacation_temperature": {
-          "name": "Vacation temperature"
+          "name": "SVOTC Vacation"
         }
       }
     },
     "select": {
       "svotc": {
         "mode": {
-          "name": "Mode"
+          "name": "SVOTC Mode"
         }
       }
     },
     "sensor": {
       "svotc": {
         "virtual_outdoor_temperature": {
-          "name": "Virtual outdoor temperature"
+          "name": "SVOTC Temp"
         },
         "offset": {
           "name": "Offset"

--- a/custom_components/svotc/translations/en.json
+++ b/custom_components/svotc/translations/en.json
@@ -31,30 +31,30 @@
     "number": {
       "svotc": {
         "brake_aggressiveness": {
-          "name": "Brake aggressiveness"
+          "name": "SVOTC Brake"
         },
         "heat_aggressiveness": {
-          "name": "Heat aggressiveness"
+          "name": "SVOTC Heat"
         },
         "comfort_temperature": {
-          "name": "Comfort temperature"
+          "name": "SVOTC Comfort"
         },
         "vacation_temperature": {
-          "name": "Vacation temperature"
+          "name": "SVOTC Vacation"
         }
       }
     },
     "select": {
       "svotc": {
         "mode": {
-          "name": "Mode"
+          "name": "SVOTC Mode"
         }
       }
     },
     "sensor": {
       "svotc": {
         "virtual_outdoor_temperature": {
-          "name": "Virtual outdoor temperature"
+          "name": "SVOTC Temp"
         },
         "offset": {
           "name": "Offset"


### PR DESCRIPTION
### Motivation
- Gör UI tydligare genom att ge SVOTC-enheterna distinkta, lättlästa friendly names utan att ändra entity_id eller funktionalitet.

### Description
- Uppdaterade översättningar i `custom_components/svotc/translations/en.json` och `custom_components/svotc/strings.json` så att entity friendly names ändras enligt krav.
- Namnändringar: `sensor.svotc` -> "SVOTC Temp", `number.svotc_brake` -> "SVOTC Brake", `number.svotc_heat` -> "SVOTC Heat", `number.svotc_comfort` -> "SVOTC Comfort", `number.svotc_vacation` -> "SVOTC Vacation", och `select.svotc_mode` -> "SVOTC Mode".
- Enhetens device name förblir `SVOTC` och inga `entity_id`-värden eller logik har ändrats.

### Testing
- Körde `pytest` i repo root; inga tester hittades och inga testfel rapporterades (ingen automatisk testsvit kördes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971064eaa90832e823c430e0a3b13d4)