### PR TITLE
Make SVOTC sensor a proper temperature entity with stable IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Exact attributes may expand slightly over time, but the core set is kept minimal
 - SVOTC is designed to be **predictable, stable, and easy to understand**.
 - It does not require any helpers.
 - It can run without price and/or weather data and will safely fall back to bypass behavior while reporting degraded states.
+- If you already have suffixed entity IDs (for example, `sensor.svotc_1234`), remove and re-add the integration to get the deterministic entity IDs.
 
 ---
 

--- a/custom_components/svotc/number.py
+++ b/custom_components/svotc/number.py
@@ -82,6 +82,12 @@ class SVOTCNumberEntity(NumberEntity, RestoreEntity):
     """Representation of a SVOTC number entity."""
 
     _attr_mode = NumberMode.BOX
+    _attr_suggested_object_ids = {
+        "brake_aggressiveness": "svotc_brake",
+        "heat_aggressiveness": "svotc_heat",
+        "comfort_temperature": "svotc_comfort",
+        "vacation_temperature": "svotc_vacation",
+    }
 
     def __init__(
         self,
@@ -92,7 +98,10 @@ class SVOTCNumberEntity(NumberEntity, RestoreEntity):
         """Initialize the SVOTC number entity."""
         self.entity_description = description
         self.coordinator = coordinator
-        self._attr_unique_id = f"{entry.entry_id}_{description.key}"
+        self._attr_unique_id = f"{DOMAIN}_{description.key}"
+        self._attr_suggested_object_id = self._attr_suggested_object_ids[
+            description.key
+        ]
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, entry.entry_id)},
             name="SVOTC",

--- a/custom_components/svotc/select.py
+++ b/custom_components/svotc/select.py
@@ -32,7 +32,8 @@ class SVOTCModeSelect(SelectEntity, RestoreEntity):
     def __init__(self, coordinator: SVOTCCoordinator, entry: ConfigEntry) -> None:
         """Initialize the mode select."""
         self.coordinator = coordinator
-        self._attr_unique_id = f"{entry.entry_id}_mode"
+        self._attr_unique_id = f"{DOMAIN}_mode"
+        self._attr_suggested_object_id = "svotc_mode"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, entry.entry_id)},
             name="SVOTC",

--- a/custom_components/svotc/sensor.py
+++ b/custom_components/svotc/sensor.py
@@ -4,11 +4,17 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.const import UnitOfTemperature
 
 from .const import DOMAIN
 from .coordinator import SVOTCCoordinator
@@ -24,23 +30,7 @@ class SVOTCSensorDescription(SensorEntityDescription):
 SENSOR_DESCRIPTIONS: tuple[SVOTCSensorDescription, ...] = (
     SVOTCSensorDescription(
         key="virtual_outdoor_temperature",
-        translation_key="virtual_outdoor_temperature",
-    ),
-    SVOTCSensorDescription(
-        key="offset",
-        translation_key="offset",
-    ),
-    SVOTCSensorDescription(
-        key="dynamic_target_temperature",
-        translation_key="dynamic_target_temperature",
-    ),
-    SVOTCSensorDescription(
-        key="status",
-        translation_key="status",
-    ),
-    SVOTCSensorDescription(
-        key="reason_code",
-        translation_key="reason_code",
+        translation_key="svotc",
     ),
 )
 
@@ -70,7 +60,11 @@ class SVOTCSensorEntity(SensorEntity):
         """Initialize the sensor."""
         self.coordinator = coordinator
         self.entity_description = description
-        self._attr_unique_id = f"{entry.entry_id}_{description.key}"
+        self._attr_unique_id = f"{DOMAIN}_{description.key}"
+        self._attr_suggested_object_id = "svotc"
+        self._attr_device_class = SensorDeviceClass.TEMPERATURE
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, entry.entry_id)},
             name="SVOTC",
@@ -79,7 +73,24 @@ class SVOTCSensorEntity(SensorEntity):
     @property
     def native_value(self) -> object:
         """Return the sensor value."""
-        return self.coordinator.data.get(self.entity_description.key)
+        value = self.coordinator.data.get(self.entity_description.key)
+        if value is None:
+            return None
+        return float(value)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, object]:
+        """Return additional sensor attributes."""
+        data = self.coordinator.data
+        return {
+            "status": data.get("status"),
+            "reason_code": data.get("reason_code"),
+            "offset_c": data.get("offset"),
+            "dynamic_target_c": data.get("dynamic_target_temperature"),
+            "mode": self.coordinator.values.get("mode"),
+            "indoor_temp_c": data.get("indoor_temperature"),
+            "outdoor_temp_c": data.get("outdoor_temperature"),
+        }
 
     @property
     def available(self) -> bool:

--- a/custom_components/svotc/strings.json
+++ b/custom_components/svotc/strings.json
@@ -53,20 +53,8 @@
     },
     "sensor": {
       "svotc": {
-        "virtual_outdoor_temperature": {
-          "name": "Virtual outdoor temperature"
-        },
-        "offset": {
-          "name": "Offset"
-        },
-        "dynamic_target_temperature": {
-          "name": "Dynamic target temperature"
-        },
-        "status": {
-          "name": "Status"
-        },
-        "reason_code": {
-          "name": "Reason code"
+        "svotc": {
+          "name": "SVOTC"
         }
       }
     }

--- a/custom_components/svotc/translations/en.json
+++ b/custom_components/svotc/translations/en.json
@@ -53,20 +53,8 @@
     },
     "sensor": {
       "svotc": {
-        "virtual_outdoor_temperature": {
-          "name": "Virtual outdoor temperature"
-        },
-        "offset": {
-          "name": "Offset"
-        },
-        "dynamic_target_temperature": {
-          "name": "Dynamic target temperature"
-        },
-        "status": {
-          "name": "Status"
-        },
-        "reason_code": {
-          "name": "Reason code"
+        "svotc": {
+          "name": "SVOTC"
         }
       }
     }


### PR DESCRIPTION
### Motivation
- Ensure `sensor.svotc` is a real temperature sensor with a numeric state and proper metadata so integrations and UIs treat it as °C temperature.
- Move textual outputs like `Startup grace` / `NEUTRAL` out of the sensor state and expose them as attributes so the state is always numeric.
- Make entity IDs deterministic so users get stable IDs (`sensor.svotc`, `number.svotc_brake`, `number.svotc_heat`, `number.svotc_comfort`, `number.svotc_vacation`, `select.svotc_mode`).

### Description
- Updated `custom_components/svotc/sensor.py` to expose a single sensor description for `virtual_outdoor_temperature`, set `SensorDeviceClass.TEMPERATURE`, `SensorStateClass.MEASUREMENT`, and `UnitOfTemperature.CELSIUS`, return a numeric `native_value` (`float`), and expose textual/status info as attributes (`status`, `reason_code`, `offset_c`, `dynamic_target_c`, `mode`, `indoor_temp_c`, `outdoor_temp_c`).
- Changed unique IDs for entities to stable values using `f"{DOMAIN}_{description.key}"` and added `suggested_object_id` values so Home Assistant will create the deterministic entity IDs noted above.
- Updated `custom_components/svotc/number.py` to use deterministic `unique_id` and provide `suggested_object_id` mapping for the four number entities so they become `number.svotc_brake`, `number.svotc_heat`, `number.svotc_comfort`, and `number.svotc_vacation`.
- Updated `custom_components/svotc/select.py` to use a deterministic `unique_id` and `suggested_object_id` for `select.svotc_mode`.
- Simplified translations in `custom_components/svotc/strings.json` and `translations/en.json` to reflect the single `sensor.svotc` entity and kept all UI strings in English.
- Added documentation note in `README.md` advising users that existing suffixed entities (e.g. `sensor.svotc_1234`) may need the integration removed and re-added to get the new deterministic entity IDs.

### Testing
- Ran `pytest`; the test run completed and collected 0 items (no automated tests present in this repository). No failures were reported by the test run.
- No other automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971077c72a8832ebdc1aa1358c0bdac)