### PR TITLE
Fix SVOTC entity ID duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Exact attributes may expand slightly over time, but the core set is kept minimal
 - SVOTC is designed to be **predictable, stable, and easy to understand**.
 - It does not require any helpers.
 - It can run without price and/or weather data and will safely fall back to bypass behavior while reporting degraded states.
-- If you already have suffixed entity IDs (for example, `sensor.svotc_1234`), remove and re-add the integration to get the deterministic entity IDs.
+- Existing entities may keep their old entity IDs in the entity registry; remove and re-add the integration (or delete the old entities from the entity registry) to get the shorter `sensor.svotc` / `number.svotc_*` / `select.svotc_mode` IDs.
 
 ---
 

--- a/custom_components/svotc/number.py
+++ b/custom_components/svotc/number.py
@@ -83,10 +83,16 @@ class SVOTCNumberEntity(NumberEntity, RestoreEntity):
 
     _attr_mode = NumberMode.BOX
     _attr_suggested_object_ids = {
-        "brake_aggressiveness": "svotc_brake",
-        "heat_aggressiveness": "svotc_heat",
-        "comfort_temperature": "svotc_comfort",
-        "vacation_temperature": "svotc_vacation",
+        "brake_aggressiveness": "brake",
+        "heat_aggressiveness": "heat",
+        "comfort_temperature": "comfort",
+        "vacation_temperature": "vacation",
+    }
+    _attr_unique_ids = {
+        "brake_aggressiveness": f"{DOMAIN}_brake",
+        "heat_aggressiveness": f"{DOMAIN}_heat",
+        "comfort_temperature": f"{DOMAIN}_comfort",
+        "vacation_temperature": f"{DOMAIN}_vacation",
     }
 
     def __init__(
@@ -98,7 +104,7 @@ class SVOTCNumberEntity(NumberEntity, RestoreEntity):
         """Initialize the SVOTC number entity."""
         self.entity_description = description
         self.coordinator = coordinator
-        self._attr_unique_id = f"{DOMAIN}_{description.key}"
+        self._attr_unique_id = self._attr_unique_ids[description.key]
         self._attr_suggested_object_id = self._attr_suggested_object_ids[
             description.key
         ]

--- a/custom_components/svotc/select.py
+++ b/custom_components/svotc/select.py
@@ -33,7 +33,7 @@ class SVOTCModeSelect(SelectEntity, RestoreEntity):
         """Initialize the mode select."""
         self.coordinator = coordinator
         self._attr_unique_id = f"{DOMAIN}_mode"
-        self._attr_suggested_object_id = "svotc_mode"
+        self._attr_suggested_object_id = "mode"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, entry.entry_id)},
             name="SVOTC",

--- a/custom_components/svotc/sensor.py
+++ b/custom_components/svotc/sensor.py
@@ -60,7 +60,7 @@ class SVOTCSensorEntity(SensorEntity):
         """Initialize the sensor."""
         self.coordinator = coordinator
         self.entity_description = description
-        self._attr_unique_id = f"{DOMAIN}_{description.key}"
+        self._attr_unique_id = f"{DOMAIN}_sensor"
         self._attr_suggested_object_id = "svotc"
         self._attr_device_class = SensorDeviceClass.TEMPERATURE
         self._attr_state_class = SensorStateClass.MEASUREMENT


### PR DESCRIPTION
### Motivation
- Entities were being created with duplicated prefixes (e.g. `number.svotc_svotc_brake_aggressiveness`) due to `svotc_` appearing in per-entity object_id suggestions.
- The integration needs stable, short `object_id`/`suggested_object_id` values and stable `unique_id`s so Home Assistant produces deterministic entity_ids like `sensor.svotc` and `number.svotc_brake`.
- Friendly names and control logic must remain unchanged while correcting only the ID generation.

### Description
- Removed the `svotc_` prefix from suggested object IDs for number and select entities so number keys are `brake`, `heat`, `comfort`, `vacation` and select key is `mode`, while keeping the sensor object id as `svotc`.
- Introduced stable short `unique_id` values: `svotc_sensor`, `svotc_brake`, `svotc_heat`, `svotc_comfort`, `svotc_vacation`, and `svotc_mode` (implemented in `custom_components/svotc/number.py`, `select.py`, and `sensor.py`).
- Kept device name and translation-based friendly names unchanged, and added a README migration note documenting how to get the new short IDs.

### Testing
- Ran `python -m pytest`; no tests were collected (0 items).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69710bd1f65c832e8d00b8c961340d02)