### PR TITLE
Adjust SVOTC entity IDs and add migration to shorten defaults

### DIFF
--- a/custom_components/svotc/__init__.py
+++ b/custom_components/svotc/__init__.py
@@ -8,6 +8,7 @@ from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
 from .coordinator import SVOTCCoordinator
+from .entity_migration import async_migrate_entity_ids
 
 PLATFORMS: list[Platform] = [Platform.NUMBER, Platform.SELECT, Platform.SENSOR]
 
@@ -17,6 +18,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = SVOTCCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    await async_migrate_entity_ids(hass, entry)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 

--- a/custom_components/svotc/entity_migration.py
+++ b/custom_components/svotc/entity_migration.py
@@ -1,0 +1,83 @@
+"""Entity ID migration helpers for SVOTC."""
+
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .const import DOMAIN
+from .number import NUMBER_OBJECT_IDS, NUMBER_UNIQUE_ID_KEYS
+from .select import SELECT_OBJECT_IDS, SELECT_UNIQUE_ID_KEYS
+from .sensor import SENSOR_OBJECT_IDS, SENSOR_UNIQUE_ID_KEYS
+
+
+PLATFORM_OBJECT_IDS: dict[Platform, dict[str, str]] = {
+    Platform.NUMBER: NUMBER_OBJECT_IDS,
+    Platform.SELECT: SELECT_OBJECT_IDS,
+    Platform.SENSOR: SENSOR_OBJECT_IDS,
+}
+
+PLATFORM_UNIQUE_ID_KEYS: dict[Platform, dict[str, str]] = {
+    Platform.NUMBER: NUMBER_UNIQUE_ID_KEYS,
+    Platform.SELECT: SELECT_UNIQUE_ID_KEYS,
+    Platform.SENSOR: SENSOR_UNIQUE_ID_KEYS,
+}
+
+
+def _legacy_object_ids(desired_object_id: str) -> set[str]:
+    return {
+        f"{DOMAIN}_{desired_object_id}",
+        f"{DOMAIN}_{DOMAIN}_{desired_object_id}",
+    }
+
+
+def _legacy_sensor_object_ids(desired_object_id: str) -> set[str]:
+    return {
+        DOMAIN,
+        f"{DOMAIN}_{DOMAIN}",
+        f"{DOMAIN}_{desired_object_id}",
+        f"{DOMAIN}_{DOMAIN}_{desired_object_id}",
+    }
+
+
+def _matches_legacy_entity_id(
+    entity_id: str,
+    platform: Platform,
+    desired_object_id: str,
+) -> bool:
+    object_id = entity_id.split(".", 1)[1]
+    if platform == Platform.SENSOR:
+        return object_id in _legacy_sensor_object_ids(desired_object_id)
+    return object_id in _legacy_object_ids(desired_object_id)
+
+
+async def async_migrate_entity_ids(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Migrate duplicated entity IDs to shorter defaults."""
+    registry = er.async_get(hass)
+    for platform, object_ids in PLATFORM_OBJECT_IDS.items():
+        unique_id_keys = PLATFORM_UNIQUE_ID_KEYS[platform]
+        for key, desired_object_id in object_ids.items():
+            new_unique_id = f"{entry.entry_id}_{key}"
+            entity_id = registry.async_get_entity_id(platform, DOMAIN, new_unique_id)
+            if entity_id is None:
+                legacy_unique_id = unique_id_keys[key]
+                legacy_entity_id = registry.async_get_entity_id(
+                    platform, DOMAIN, legacy_unique_id
+                )
+                if legacy_entity_id is not None:
+                    registry.async_update_entity(
+                        legacy_entity_id,
+                        new_unique_id=new_unique_id,
+                    )
+                    entity_id = legacy_entity_id
+            if entity_id is None:
+                continue
+            if not _matches_legacy_entity_id(entity_id, platform, desired_object_id):
+                continue
+            platform_name = platform.value
+            new_entity_id = f"{platform_name}.{desired_object_id}"
+            if registry.async_get(new_entity_id) is not None:
+                continue
+            registry.async_update_entity(entity_id, new_entity_id=new_entity_id)

--- a/custom_components/svotc/number.py
+++ b/custom_components/svotc/number.py
@@ -64,6 +64,20 @@ NUMBER_DESCRIPTIONS: tuple[SVOTCNumberDescription, ...] = (
     ),
 )
 
+NUMBER_OBJECT_IDS: dict[str, str] = {
+    "brake_aggressiveness": "brake",
+    "heat_aggressiveness": "heat",
+    "comfort_temperature": "comfort",
+    "vacation_temperature": "vacation",
+}
+
+NUMBER_UNIQUE_ID_KEYS: dict[str, str] = {
+    "brake_aggressiveness": f"{DOMAIN}_brake",
+    "heat_aggressiveness": f"{DOMAIN}_heat",
+    "comfort_temperature": f"{DOMAIN}_comfort",
+    "vacation_temperature": f"{DOMAIN}_vacation",
+}
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -82,18 +96,6 @@ class SVOTCNumberEntity(NumberEntity, RestoreEntity):
     """Representation of a SVOTC number entity."""
 
     _attr_mode = NumberMode.BOX
-    _attr_suggested_object_ids = {
-        "brake_aggressiveness": "brake",
-        "heat_aggressiveness": "heat",
-        "comfort_temperature": "comfort",
-        "vacation_temperature": "vacation",
-    }
-    _attr_unique_ids = {
-        "brake_aggressiveness": f"{DOMAIN}_brake",
-        "heat_aggressiveness": f"{DOMAIN}_heat",
-        "comfort_temperature": f"{DOMAIN}_comfort",
-        "vacation_temperature": f"{DOMAIN}_vacation",
-    }
 
     def __init__(
         self,
@@ -104,10 +106,8 @@ class SVOTCNumberEntity(NumberEntity, RestoreEntity):
         """Initialize the SVOTC number entity."""
         self.entity_description = description
         self.coordinator = coordinator
-        self._attr_unique_id = self._attr_unique_ids[description.key]
-        self._attr_suggested_object_id = self._attr_suggested_object_ids[
-            description.key
-        ]
+        self._attr_unique_id = f"{entry.entry_id}_{description.key}"
+        self._attr_suggested_object_id = NUMBER_OBJECT_IDS[description.key]
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, entry.entry_id)},
             name="SVOTC",

--- a/custom_components/svotc/select.py
+++ b/custom_components/svotc/select.py
@@ -12,6 +12,14 @@ from homeassistant.helpers.restore_state import RestoreEntity
 from .const import DEFAULT_MODE, DOMAIN, MODE_OPTIONS
 from .coordinator import SVOTCCoordinator
 
+SELECT_OBJECT_IDS: dict[str, str] = {
+    "mode": "mode",
+}
+
+SELECT_UNIQUE_ID_KEYS: dict[str, str] = {
+    "mode": f"{DOMAIN}_mode",
+}
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -32,8 +40,8 @@ class SVOTCModeSelect(SelectEntity, RestoreEntity):
     def __init__(self, coordinator: SVOTCCoordinator, entry: ConfigEntry) -> None:
         """Initialize the mode select."""
         self.coordinator = coordinator
-        self._attr_unique_id = f"{DOMAIN}_mode"
-        self._attr_suggested_object_id = "mode"
+        self._attr_unique_id = f"{entry.entry_id}_mode"
+        self._attr_suggested_object_id = SELECT_OBJECT_IDS["mode"]
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, entry.entry_id)},
             name="SVOTC",

--- a/custom_components/svotc/sensor.py
+++ b/custom_components/svotc/sensor.py
@@ -34,6 +34,14 @@ SENSOR_DESCRIPTIONS: tuple[SVOTCSensorDescription, ...] = (
     ),
 )
 
+SENSOR_OBJECT_IDS: dict[str, str] = {
+    "virtual_outdoor_temperature": "temperature",
+}
+
+SENSOR_UNIQUE_ID_KEYS: dict[str, str] = {
+    "virtual_outdoor_temperature": f"{DOMAIN}_sensor",
+}
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -60,8 +68,8 @@ class SVOTCSensorEntity(SensorEntity):
         """Initialize the sensor."""
         self.coordinator = coordinator
         self.entity_description = description
-        self._attr_unique_id = f"{DOMAIN}_sensor"
-        self._attr_suggested_object_id = "svotc"
+        self._attr_unique_id = f"{entry.entry_id}_{description.key}"
+        self._attr_suggested_object_id = SENSOR_OBJECT_IDS[description.key]
         self._attr_device_class = SensorDeviceClass.TEMPERATURE
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS


### PR DESCRIPTION
### Motivation
- Remove duplicated "svotc" prefixes and provide short, stable entity IDs and suggested object IDs so entities appear as `number.brake`, `sensor.temperature`, `select.mode`, etc., while allowing multiple config entries. 
- Provide a safe migration so previously auto-generated duplicated entity_ids are renamed to the new short form when possible without touching user-renamed entities.

### Description
- Set per-config-entry stable `unique_id` for entities using `f"{entry.entry_id}_{description.key}"` and set a single `self._attr_suggested_object_id` from introduced maps (`NUMBER_OBJECT_IDS`, `SENSOR_OBJECT_IDS`, `SELECT_OBJECT_IDS`).
- Added mapping dicts and legacy unique-id keys (`*_UNIQUE_ID_KEYS`) in each platform module to drive migrations.
- Added `custom_components/svotc/entity_migration.py` with `async_migrate_entity_ids(hass, entry)` which updates legacy unique_ids and renames only default duplicated entity_ids that match legacy patterns and where the target object_id is free.
- Wired migration to run during `async_setup_entry` before forwarding platform setups so entities are added with the new suggestions.

### Testing
- Ran `pytest`; no tests were collected in this repository (no automated tests executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697113db54b4832e869020fdd1a4fc2d)