### PR TITLE
Support separate today/tomorrow price sensors and enhanced price extraction

### DIFF
--- a/custom_components/svotc/config_flow.py
+++ b/custom_components/svotc/config_flow.py
@@ -13,6 +13,8 @@ from .const import (
     CONF_INDOOR_TEMPERATURE,
     CONF_OUTDOOR_TEMPERATURE,
     CONF_PRICE_ENTITY,
+    CONF_PRICE_ENTITY_TODAY,
+    CONF_PRICE_ENTITY_TOMORROW,
     CONF_WEATHER_ENTITY,
     DOMAIN,
 )
@@ -20,6 +22,10 @@ from .const import (
 
 def _schema(defaults: dict[str, Any]) -> vol.Schema:
     """Build the config schema with optional entity selectors."""
+    price_today_default = defaults.get(CONF_PRICE_ENTITY_TODAY) or defaults.get(
+        CONF_PRICE_ENTITY
+    )
+    price_tomorrow_default = defaults.get(CONF_PRICE_ENTITY_TOMORROW)
     return vol.Schema(
         {
             vol.Optional(
@@ -34,9 +40,15 @@ def _schema(defaults: dict[str, Any]) -> vol.Schema:
             ): selector.EntitySelector(
                 selector.EntitySelectorConfig(domain=["sensor"])
             ),
+            vol.Required(
+                CONF_PRICE_ENTITY_TODAY,
+                default=price_today_default,
+            ): selector.EntitySelector(
+                selector.EntitySelectorConfig(domain=["sensor"])
+            ),
             vol.Optional(
-                CONF_PRICE_ENTITY,
-                default=defaults.get(CONF_PRICE_ENTITY),
+                CONF_PRICE_ENTITY_TOMORROW,
+                default=price_tomorrow_default,
             ): selector.EntitySelector(
                 selector.EntitySelectorConfig(domain=["sensor"])
             ),

--- a/custom_components/svotc/const.py
+++ b/custom_components/svotc/const.py
@@ -5,6 +5,8 @@ DOMAIN = "svotc"
 CONF_INDOOR_TEMPERATURE = "indoor_temperature"
 CONF_OUTDOOR_TEMPERATURE = "outdoor_temperature"
 CONF_PRICE_ENTITY = "price_entity"
+CONF_PRICE_ENTITY_TODAY = "price_entity_today"
+CONF_PRICE_ENTITY_TOMORROW = "price_entity_tomorrow"
 CONF_WEATHER_ENTITY = "weather_entity"
 
 DEFAULT_BRAKE_AGGRESSIVENESS = 3

--- a/custom_components/svotc/prices.py
+++ b/custom_components/svotc/prices.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
 from datetime import datetime
 from typing import Any
 
@@ -13,63 +12,49 @@ from homeassistant.util import dt as dt_util
 def _parse_datetime(value: Any) -> datetime | None:
     """Parse a datetime value if possible."""
     if isinstance(value, datetime):
-        return value
+        return dt_util.as_utc(value)
     if isinstance(value, str):
-        return dt_util.parse_datetime(value)
+        parsed = dt_util.parse_datetime(value)
+        if parsed is None:
+            return None
+        return dt_util.as_utc(parsed)
     return None
 
 
-def _extract_price_values(entries: Iterable[Any], now: datetime) -> list[float]:
-    """Extract price values from iterable entries."""
-    values: list[float] = []
-    for entry in entries:
-        if isinstance(entry, dict):
-            if "start" in entry or "startsAt" in entry or "datetime" in entry:
-                start = (
-                    entry.get("start")
-                    or entry.get("startsAt")
-                    or entry.get("datetime")
-                )
-                parsed = _parse_datetime(start)
-                if parsed is not None and parsed < now:
-                    continue
-            for key in ("value", "price", "total", "energy"):
-                if key in entry:
-                    try:
-                        values.append(float(entry[key]))
-                    except (TypeError, ValueError):
-                        pass
-                    break
-        else:
-            try:
-                values.append(float(entry))
-            except (TypeError, ValueError):
-                continue
-    return values
-
-
-def extract_price_series(
-    state: State | None, now: datetime
-) -> tuple[float | None, list[float]]:
-    """Extract current price and a price series from an entity."""
+def extract_price_entries(state: State | None) -> list[dict[str, object]]:
+    """Extract price entries from a state attribute payload."""
     if state is None or state.state in ("unknown", "unavailable"):
-        return None, []
-    try:
-        current_price = float(state.state)
-    except ValueError:
-        current_price = None
+        return []
+    data = state.attributes.get("data")
+    if not isinstance(data, list):
+        return []
+    entries: list[dict[str, object]] = []
+    for entry in data:
+        if not isinstance(entry, dict):
+            continue
+        start = _parse_datetime(entry.get("start"))
+        end = _parse_datetime(entry.get("end"))
+        if start is None or end is None:
+            continue
+        try:
+            price = float(entry["price"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        entries.append({"start": start, "end": end, "price": price})
+    return entries
 
-    attributes = state.attributes
-    series: list[float] = []
-    for key in ("raw_today", "raw_tomorrow", "today", "tomorrow", "prices"):
-        data = attributes.get(key)
-        if isinstance(data, list):
-            series.extend(_extract_price_values(data, now))
 
-    if not series and current_price is not None:
-        series = [current_price]
-
-    return current_price, series
+def select_current_price(
+    entries: list[dict[str, object]], now: datetime
+) -> float | None:
+    """Select the current price from matching entries."""
+    for entry in sorted(entries, key=lambda item: item["start"]):
+        start = entry["start"]
+        end = entry["end"]
+        if isinstance(start, datetime) and isinstance(end, datetime):
+            if start <= now < end:
+                return float(entry["price"])
+    return None
 
 
 def _percentile(values: list[float], percentile: float) -> float:
@@ -86,14 +71,22 @@ def _percentile(values: list[float], percentile: float) -> float:
     return ordered[lower] * (1 - weight) + ordered[upper] * weight
 
 
+def price_percentiles(prices: list[float]) -> tuple[float | None, float | None]:
+    """Return (p30, p70) percentiles for prices."""
+    if not prices:
+        return None, None
+    try:
+        return _percentile(prices, 0.30), _percentile(prices, 0.70)
+    except ValueError:
+        return None, None
+
+
 def classify_price(current_price: float | None, prices: list[float]) -> str | None:
     """Classify the current price as cheap, neutral, or expensive."""
     if current_price is None or not prices:
         return None
-    try:
-        p30 = _percentile(prices, 0.30)
-        p70 = _percentile(prices, 0.70)
-    except ValueError:
+    p30, p70 = price_percentiles(prices)
+    if p30 is None or p70 is None:
         return None
     if current_price <= p30:
         return "cheap"

--- a/custom_components/svotc/sensor.py
+++ b/custom_components/svotc/sensor.py
@@ -109,6 +109,15 @@ class SVOTCSensorEntity(SensorEntity):
             "mode": self.coordinator.values.get("mode"),
             "indoor_temp_c": data.get("indoor_temperature"),
             "outdoor_temp_c": data.get("outdoor_temperature"),
+            "price_entities_used": data.get("price_entities_used"),
+            "prices_count_today": data.get("prices_count_today"),
+            "prices_count_tomorrow": data.get("prices_count_tomorrow"),
+            "prices_count_total": data.get("prices_count_total"),
+            "current_price": data.get("current_price"),
+            "price_state": data.get("price_state"),
+            "p30": data.get("p30"),
+            "p70": data.get("p70"),
+            "missing_inputs": data.get("missing_inputs"),
         }
 
     @property

--- a/custom_components/svotc/strings.json
+++ b/custom_components/svotc/strings.json
@@ -3,11 +3,12 @@
     "step": {
       "user": {
         "title": "SVOTC setup",
-        "description": "Select optional entities or leave blank for auto-detect.",
+        "description": "Select the required price sensor and optional entities or leave blank for auto-detect.",
         "data": {
           "indoor_temperature": "Indoor temperature sensor",
           "outdoor_temperature": "Outdoor temperature sensor",
-          "price_entity": "Price sensor",
+          "price_entity_today": "Price sensor (today)",
+          "price_entity_tomorrow": "Price sensor (tomorrow)",
           "weather_entity": "Weather entity"
         }
       }
@@ -17,11 +18,12 @@
     "step": {
       "init": {
         "title": "SVOTC options",
-        "description": "Update optional entity selections or leave blank for auto-detect.",
+        "description": "Update the required price sensor and optional entity selections or leave blank for auto-detect.",
         "data": {
           "indoor_temperature": "Indoor temperature sensor",
           "outdoor_temperature": "Outdoor temperature sensor",
-          "price_entity": "Price sensor",
+          "price_entity_today": "Price sensor (today)",
+          "price_entity_tomorrow": "Price sensor (tomorrow)",
           "weather_entity": "Weather entity"
         }
       }

--- a/custom_components/svotc/translations/en.json
+++ b/custom_components/svotc/translations/en.json
@@ -3,11 +3,12 @@
     "step": {
       "user": {
         "title": "SVOTC setup",
-        "description": "Select optional entities or leave blank for auto-detect.",
+        "description": "Select the required price sensor and optional entities or leave blank for auto-detect.",
         "data": {
           "indoor_temperature": "Indoor temperature sensor",
           "outdoor_temperature": "Outdoor temperature sensor",
-          "price_entity": "Price sensor",
+          "price_entity_today": "Price sensor (today)",
+          "price_entity_tomorrow": "Price sensor (tomorrow)",
           "weather_entity": "Weather entity"
         }
       }
@@ -17,11 +18,12 @@
     "step": {
       "init": {
         "title": "SVOTC options",
-        "description": "Update optional entity selections or leave blank for auto-detect.",
+        "description": "Update the required price sensor and optional entity selections or leave blank for auto-detect.",
         "data": {
           "indoor_temperature": "Indoor temperature sensor",
           "outdoor_temperature": "Outdoor temperature sensor",
-          "price_entity": "Price sensor",
+          "price_entity_today": "Price sensor (today)",
+          "price_entity_tomorrow": "Price sensor (tomorrow)",
           "weather_entity": "Weather entity"
         }
       }


### PR DESCRIPTION
### Motivation

- Allow users to configure separate price sensors for today and tomorrow so the coordinator can merge and prefer today slots when computing current price. 
- Accept a standardized `data` attribute payload from price sensors (list of dicts with `start`, `end`, `price`) for more robust slot handling. 
- Improve observability and logging around missing/partial price inputs and expose debug attributes for troubleshooting.

### Description

- Added new config constants `CONF_PRICE_ENTITY_TODAY` and `CONF_PRICE_ENTITY_TOMORROW` in `const.py` and updated the config/options UI to make `price_entity_today` required and `price_entity_tomorrow` optional (`config_flow.py` and UI strings/translations updated). 
- Reworked price parsing in `prices.py`: added `extract_price_entries`, `select_current_price` and `price_percentiles` to parse the `data` attribute into UTC-aware entries and compute percentiles. 
- Updated coordinator (`coordinator.py`) to read `price_entity_today` always and `price_entity_tomorrow` only if configured; build a `combined_entries` series = `today + tomorrow` when tomorrow is valid; determine `current_price` by matching slots with a preference for today slots when overlapping; and compute `price_series`, `p30`, `p70` and `price_class`. 
- Added logging helpers to the coordinator: `_log_today_missing` (warning once per transition after 60s startup grace) and `_log_tomorrow_issue` (debug immediately, escalate to warning only after 10 minutes throttled). 
- When today data is missing/empty the coordinator marks price unavailable and uses BYPASS-style behavior (offset 0) with `reason_code = "MISSING_PRICE"`; if tomorrow is missing before publication it's treated as non-fatal (debug and possibly later warning), continuing with today-only data. 
- Exposed debug attributes on the SVOTC sensor (`sensor.svotc`) via coordinator outputs and `extra_state_attributes`: `price_entities_used`, `prices_count_today`, `prices_count_tomorrow`, `prices_count_total`, `current_price`, `price_state`, `p30`, `p70`, and `missing_inputs`. 
- Kept classification behavior (`classify_price`) but switched internal percentile calculation to use the new `price_percentiles` helper.

### Testing

- Ran the repository test command `python -m pytest`; the run completed successfully but reported `collected 0 items` (no automated tests in this workspace).
- Performed local static verification by running the code updates and committing the changes; no runtime HA integration tests were run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697321a9a2c8832e882460f4f935b6ce)