### PR TITLE
Restore ramp baseline on startup and show aggressiveness sliders

### DIFF
--- a/custom_components/svotc/number.py
+++ b/custom_components/svotc/number.py
@@ -47,7 +47,7 @@ NUMBER_DESCRIPTIONS: tuple[SVOTCNumberDescription, ...] = (
         translation_key="heat_aggressiveness",
         default=DEFAULT_HEAT_AGGRESSIVENESS,
         native_min_value=0,
-        native_max_value=10,
+        native_max_value=5,
         native_step=1,
     ),
     SVOTCNumberDescription(
@@ -126,6 +126,10 @@ class SVOTCNumberEntity(NumberEntity, RestoreEntity):
             identifiers={(DOMAIN, entry.entry_id)},
             name="SVOTC",
         )
+        if description.key in {"brake_aggressiveness", "heat_aggressiveness"}:
+            self._attr_mode = NumberMode.SLIDER
+        else:
+            self._attr_mode = NumberMode.BOX
 
     @property
     def native_value(self) -> float:


### PR DESCRIPTION
### Motivation
- Ensure the virtual outdoor temperature ramp baseline is preserved across Home Assistant restarts so the offset does not reset to 0.0.
- Improve UX by making brake and heat aggressiveness controllable with sliders in the UI.

### Description
- Make `SVOTCSensorEntity` a `RestoreEntity` and implement `async_added_to_hass()` to read the last stored state and restore `last_applied_offset_c` from `applied_offset_c` (preferred), or `offset_c`, or `last_applied_offset_c`, converting to `float` with a fallback of `0.0`.
- Write the restored baseline into the coordinator using `self.coordinator._last_offset = restored_value` and emit a single INFO log: "Restored last_applied_offset_c=... from previous state".
- Present `brake_aggressiveness` and `heat_aggressiveness` as sliders by setting `_attr_mode = NumberMode.SLIDER` for those keys in `SVOTCNumberEntity.__init__` and set `heat_aggressiveness` range to `0..5` with `step=1`.

### Testing
- Ran `python -m pytest` in the repository and no tests were collected (zero tests run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69732db1167c832ea96365432bd70f2b)