### PR TITLE
Handle missing tomorrow prices and add troubleshooting guide

### DIFF
--- a/custom_components/svotc/coordinator.py
+++ b/custom_components/svotc/coordinator.py
@@ -232,6 +232,8 @@ class SVOTCCoordinator(DataUpdateCoordinator[dict[str, object]]):
             missing_inputs.append("price_today")
         if current_price is None and not today_missing:
             missing_inputs.append("current_price")
+        if price_entity_tomorrow and not tomorrow_valid:
+            missing_inputs.append("price_tomorrow")
 
         critical_missing = False
         if indoor_entity_id and indoor_temp is None:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,25 @@
+# Troubleshooting
+
+## Tomorrow prices are empty before ~13:30
+Many Nord Pool-backed sensors do not publish tomorrow's prices until around 13:30 local time. Until then, the tomorrow list can be empty, which is expected. SVOTC continues to operate with today's prices only.
+
+If you use templates like `min()` on the tomorrow list, guard against empty data to avoid warnings. Example:
+
+```jinja
+{% set tomorrow_prices = state_attr('sensor.price_tomorrow', 'prices') or [] %}
+{% if tomorrow_prices %}
+  {{ (tomorrow_prices | map(attribute='price') | list | min) }}
+{% else %}
+  unknown
+{% endif %}
+```
+
+## Unique ID collisions in template sensors
+Home Assistant requires template sensors to have unique IDs. If you reuse an ID (for example, a `ps_status_summary` sensor copied between configurations), Home Assistant will show a collision and only one entity will be created.
+
+Fix:
+- Update the template sensor configuration to use a unique `unique_id`.
+- Remove the old entity from **Settings → Devices & Services → Entities** (or delete the entry in the entity registry) so Home Assistant can recreate it with the new ID.
+
+## SVOTC sensor updates
+SVOTC sensor entities are updated by the coordinator. They do not poll on their own, so they must inherit from `CoordinatorEntity`. If you see sensors stuck with old timestamps, verify the integration is using coordinator-driven entities and that the coordinator is refreshing successfully.


### PR DESCRIPTION
### Motivation
- Tomorrow price feeds can legitimately be empty (e.g. Nord Pool tomorrow feed before ~13:30) and the coordinator did not explicitly record that condition in debug attributes, which makes troubleshooting harder while the integration should continue to operate on today-only prices.
- The sensor entity was already coordinator-driven (inherits `CoordinatorEntity` and uses `super().__init__(coordinator)` and `_attr_should_poll = False`), so no sensor changes were required to address the stuck-update symptom.

### Description
- Append `"price_tomorrow"` to the coordinator `missing_inputs` list when a tomorrow price entity is configured but its extracted entries are empty, so debug attributes like `missing_inputs` and `tomorrow_available` reflect the missing input correctly (`custom_components/svotc/coordinator.py`).
- Add `docs/troubleshooting.md` documenting why tomorrow prices can be empty before ~13:30, how to avoid template warnings (e.g. `min()` on empty lists), template sensor `unique_id` collisions and how to resolve them, and a note that SVOTC entities are coordinator-driven.

### Testing
- Ran `python -m pytest` which executed successfully but collected no tests (no automated tests present).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976fd654a40832eafbbc744074ac8fb)