### PR TITLE
Make SVOTC sensor coordinator-driven

### DIFF
--- a/custom_components/svotc/sensor.py
+++ b/custom_components/svotc/sensor.py
@@ -162,3 +162,11 @@ class SVOTCSensorEntity(CoordinatorEntity, SensorEntity, RestoreEntity):
     def available(self) -> bool:
         """Return entity availability."""
         return self.coordinator.last_update_success
+
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        value = self.coordinator.data.get(self.entity_description.key)
+        _LOGGER.debug(
+            "Coordinator update for %s: %s", self.entity_description.key, value
+        )
+        super()._handle_coordinator_update()


### PR DESCRIPTION
### Motivation
- The SVOTC virtual outdoor temperature sensor could appear stale because coordinator updates were not explicitly surfaced by the entity, making it harder to confirm and trigger state refreshes.

### Description
- Add an override of `SVOTCSensorEntity._handle_coordinator_update` that logs a DEBUG line with the updated `entity_description.key` value and then calls `super()._handle_coordinator_update()` so the entity uses `CoordinatorEntity`’s update mechanism; the entity continues to inherit from `CoordinatorEntity` and uses `_attr_should_poll = False`.
- How to test manually: reload the SVOTC integration or restart Home Assistant, trigger a coordinator refresh (wait for the update interval or force a refresh), and verify the sensor's `last_updated` changes and the debug log contains the `Coordinator update for <key>: <value>` line.

### Testing
- Ran `pytest` in the repository which reported no tests were found and exited with code 5 (no automated tests exercised).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976ff8e4b88832e9c56a3fcb7e79917)