### PR TITLE
Make SVOTC coordinator comfort-first with brake guardrail and improved observability

### DIFF
--- a/custom_components/svotc/sensor.py
+++ b/custom_components/svotc/sensor.py
@@ -132,31 +132,9 @@ class SVOTCSensorEntity(CoordinatorEntity, SensorEntity, RestoreEntity):
     @property
     def extra_state_attributes(self) -> dict[str, object]:
         """Return additional sensor attributes."""
-        data = self.coordinator.data
-        return {
-            "status": data.get("status"),
-            "reason_code": data.get("reason_code"),
-            "offset_c": data.get("offset"),
-            "requested_offset_c": data.get("requested_offset"),
-            "applied_offset_c": data.get("applied_offset"),
-            "ramp_limited": data.get("ramp_limited"),
-            "max_delta_per_step": data.get("max_delta_per_step"),
-            "last_applied_offset_c": data.get("last_applied_offset"),
-            "dynamic_target_c": data.get("dynamic_target_temperature"),
-            "mode": self.coordinator.values.get("mode"),
-            "indoor_temp_c": data.get("indoor_temperature"),
-            "outdoor_temp_c": data.get("outdoor_temperature"),
-            "price_entities_used": data.get("price_entities_used"),
-            "prices_count_today": data.get("prices_count_today"),
-            "prices_count_tomorrow": data.get("prices_count_tomorrow"),
-            "tomorrow_available": data.get("tomorrow_available"),
-            "prices_count_total": data.get("prices_count_total"),
-            "current_price": data.get("current_price"),
-            "price_state": data.get("price_state"),
-            "p30": data.get("p30"),
-            "p70": data.get("p70"),
-            "missing_inputs": data.get("missing_inputs"),
-        }
+        data = dict(self.coordinator.data)
+        data["mode"] = self.coordinator.values.get("mode")
+        return data
 
     @property
     def available(self) -> bool:


### PR DESCRIPTION
### Motivation
- Move SVOTC to be truly coordinator-driven and make the comfort PI the primary controller so indoor comfort is preserved whenever reasonable.
- Apply price braking as a non-negative bias constrained by the existing `brake_aggressiveness` slider rather than a mode that can introduce confusing net offsets.
- Improve observability by exposing internal offsets/modes and reduce noisy "missing tomorrow" warnings before local publish time.

### Description
- Sensor: the sensor now exposes the coordinator output directly in its attributes by returning `dict(self.coordinator.data)` and adding `mode` from `self.coordinator.values`, so the sensor mirrors coordinator state and new observability fields. (`custom_components/svotc/sensor.py`)  
- Coordinator: control logic refactored to make the comfort PI the baseline controller and compute price braking as a non-negative bias derived from `compute_price_offset` and scaled/guard-railed by a new `heat_need_factor` and a `brake_reduction_strength` derived from `brake_aggressiveness`. The effective price bias is reduced when the house needs heat so braking cannot flip a needed heating request to net-cooling. (`custom_components/svotc/coordinator.py`)  
- Coordinator: added new observable output fields: `comfort_offset_c`, `price_offset_c`, `effective_price_offset_c`, `requested_offset_c`, `applied_offset_c`, and `effective_mode` and included these in the coordinator result for exposure by the sensor. (`custom_components/svotc/coordinator.py`)  
- Tomorrow prices: suppress tomorrow-price missing warnings/`missing_inputs` until local time >= `13:45` via `_should_require_tomorrow(now)` so early empty publishes do not trigger noisy missing-input alerts. (`custom_components/svotc/coordinator.py`)  
- Status/reason logic: derive `status` and `reason_code` from the net effect and whether braking is actively constraining comfort, only labeling braking when braking is dominant or actively limiting comfort; price state mapping adjusted to reflect brake/boost/neutral consistently. (`custom_components/svotc/coordinator.py`)  
- Logging: improved debug logging to show `price_offset`, `effective_price_offset` and `comfort_offset` in the single requested-offset debug line. (`custom_components/svotc/coordinator.py`)  
- Files changed: `custom_components/svotc/coordinator.py`, `custom_components/svotc/sensor.py`.

Manual verification steps (to run after installing changes):
- Elevated/expensive price + indoor near/above target => `effective_mode`/`status` shows braking and net `requested_offset_c` is positive (braking).  
- Elevated price + indoor below target => `comfort_offset_c` is negative (heating request) and net `requested_offset_c` remains heating (sign preserved); `status` must not claim braking if net effect is heating, and `reason_code` should reflect comfort or `PRICE_LIMITING_COMFORT` when braking constrained comfort.  
- Adjust `brake_aggressiveness` and verify `price_offset_c` / `effective_price_offset_c` scale and that higher aggressiveness reduces how much braking is reduced by the guardrail.

### Testing
- Ran unit tests with `pytest` and all existing tests passed: `4 passed` (see `tests/test_control.py`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978518c6378832e894fe39ae2e38987)