### PR TITLE
Lägg till temperaturmetadata för virtual_outdoor_temperature

### DIFF
--- a/custom_components/svotc/sensor.py
+++ b/custom_components/svotc/sensor.py
@@ -60,6 +60,9 @@ SENSOR_DESCRIPTIONS: tuple[SVOTCSensorDescription, ...] = (
     SVOTCSensorDescription(
         key="virtual_outdoor_temperature",
         translation_key="virtual_outdoor_temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
 )
 


### PR DESCRIPTION
### Motivation
- Säkerställa att temperaturvärden exponeras som riktiga temperatur‑sensorer i Home Assistant så UI och recorder hanterar dem korrekt; `virtual_outdoor_temperature` saknade metadata.

### Description
- Lagt till `device_class=SensorDeviceClass.TEMPERATURE`, `native_unit_of_measurement=UnitOfTemperature.CELSIUS` och `state_class=SensorStateClass.MEASUREMENT` för `virtual_outdoor_temperature` i `custom_components/svotc/sensor.py`; `dynamic_target_temperature` behölls med samma metadata.

- Offset‑värden (`comfort_offset_c`, `price_offset_c`, `requested_offset_c`, `applied_offset_c` etc.) exponeras som attribut i koordinatorns data och representerar temperaturavvikelser i °C, så de lämnas som attribut och har inte egna `device_class`/sensorbeskrivningar.

- `translation_key`-fältet förblir oförändrat för alla sensorer.

### Testing
- Körde `pytest` mot projektets tester och alla tester passerade (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697af41e95dc832e8928518ef38b1741)