### PR TITLE
Implement P80/P70 stateful brake hysteresis with decaying offsets and comfort guard

### DIFF
--- a/custom_components/svotc/control.py
+++ b/custom_components/svotc/control.py
@@ -15,6 +15,17 @@ class ComfortPIResult:
     filtered_error: float
 
 
+@dataclass(slots=True)
+class BrakeDecision:
+    """Decision details for price braking."""
+
+    target_offset: float
+    brake_active: bool
+    in_peak: bool
+    reason_code: str | None
+    limited_by_comfort: bool
+
+
 def clamp(value: float, min_value: float, max_value: float) -> float:
     """Clamp a value between min and max."""
     return max(min_value, min(max_value, value))
@@ -57,6 +68,63 @@ def compute_price_offset(
     ratio = (current_price - p30) / (p70 - p30)
     ratio = clamp(ratio, 0.0, 1.0)
     return ratio * max_brake_offset, ratio
+
+
+def compute_brake_target(
+    current_price: float | None,
+    p70: float | None,
+    p80: float | None,
+    max_brake_offset: float,
+    brake_active: bool,
+    last_offset: float | None,
+    comfort_guard_active: bool,
+) -> BrakeDecision:
+    """Compute a stateful brake target using P80 enter and P70 exit thresholds."""
+    if (
+        current_price is None
+        or p70 is None
+        or p80 is None
+        or max_brake_offset <= 0
+        or p80 <= p70
+    ):
+        return BrakeDecision(
+            target_offset=0.0,
+            brake_active=False,
+            in_peak=False,
+            reason_code=None,
+            limited_by_comfort=False,
+        )
+
+    in_peak = current_price > p80
+    if in_peak:
+        next_brake_active = True
+    elif current_price < p70:
+        next_brake_active = False
+    else:
+        next_brake_active = brake_active
+
+    target_offset = max_brake_offset if in_peak else 0.0
+    limited_by_comfort = False
+    if comfort_guard_active and target_offset > 0.0:
+        cap = last_offset if last_offset is not None else 0.0
+        if target_offset > cap:
+            target_offset = cap
+            limited_by_comfort = True
+
+    if in_peak:
+        reason_code = "PRICE_BRAKE_ENTER" if not brake_active else "PRICE_BRAKE_HOLD"
+    elif brake_active:
+        reason_code = "PRICE_BRAKE_DECAY"
+    else:
+        reason_code = None
+
+    return BrakeDecision(
+        target_offset=target_offset,
+        brake_active=next_brake_active,
+        in_peak=in_peak,
+        reason_code=reason_code,
+        limited_by_comfort=limited_by_comfort,
+    )
 
 
 def smooth_asymmetric(

--- a/custom_components/svotc/prices.py
+++ b/custom_components/svotc/prices.py
@@ -95,11 +95,12 @@ def classify_price(current_price: float | None, prices: list[float]) -> str | No
     """Classify the current price as cheap, neutral, or expensive."""
     if current_price is None or not prices:
         return None
-    p30, p70 = price_percentiles(prices)
-    if p30 is None or p70 is None:
+    p30, _p70 = price_percentiles(prices)
+    p80 = price_percentile(prices, 0.80)
+    if p30 is None or p80 is None:
         return None
     if current_price <= p30:
         return "cheap"
-    if current_price >= p70:
+    if current_price > p80:
         return "expensive"
     return "neutral"

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -17,6 +17,7 @@ sys.modules["svotc_control"] = CONTROL
 SPEC.loader.exec_module(CONTROL)
 
 compute_price_offset = CONTROL.compute_price_offset
+compute_brake_target = CONTROL.compute_brake_target
 smooth_asymmetric = CONTROL.smooth_asymmetric
 update_comfort_pi = CONTROL.update_comfort_pi
 
@@ -58,3 +59,62 @@ def test_update_comfort_pi_integrator_and_clamp() -> None:
     )
     assert result.integrator == -2.0
     assert result.offset == -3.0
+
+
+def test_brake_hysteresis_and_decay_between_peaks() -> None:
+    p70 = 70.0
+    p80 = 80.0
+    max_brake = 4.0
+    brake_active = False
+    last_offset: float | None = None
+    offsets: list[float] = []
+    prices = [60.0, 90.0, 75.0, 70.0, 60.0, 90.0]
+
+    for price in prices:
+        decision = compute_brake_target(
+            current_price=price,
+            p70=p70,
+            p80=p80,
+            max_brake_offset=max_brake,
+            brake_active=brake_active,
+            last_offset=last_offset,
+            comfort_guard_active=False,
+        )
+        brake_active = decision.brake_active
+        last_offset = smooth_asymmetric(decision.target_offset, last_offset, 60.0, 900.0)
+        offsets.append(last_offset)
+
+    assert offsets[1] >= offsets[0]
+    assert offsets[2] < offsets[1]
+    assert offsets[3] < offsets[2]
+    assert offsets[4] < offsets[3]
+    assert offsets[5] > offsets[4]
+
+
+def test_brake_does_not_stick_at_p70() -> None:
+    decision = compute_brake_target(
+        current_price=70.0,
+        p70=70.0,
+        p80=80.0,
+        max_brake_offset=4.0,
+        brake_active=True,
+        last_offset=3.0,
+        comfort_guard_active=False,
+    )
+    assert decision.target_offset == 0.0
+    decayed = smooth_asymmetric(decision.target_offset, 3.0, 60.0, 900.0)
+    assert decayed < 3.0
+
+
+def test_comfort_guard_limits_brake_ramp() -> None:
+    guarded = compute_brake_target(
+        current_price=90.0,
+        p70=70.0,
+        p80=80.0,
+        max_brake_offset=4.0,
+        brake_active=False,
+        last_offset=1.0,
+        comfort_guard_active=True,
+    )
+    assert guarded.target_offset == 1.0
+    assert guarded.limited_by_comfort is True


### PR DESCRIPTION
### Motivation
- Root cause: braking could get stuck because the previous logic used a single threshold and hold semantics that effectively tracked `current_price` against the brake percentile and kept a fixed elevated offset instead of decaying it, lacked a clear P80 enter / P70 exit hysteresis and did not limit ramp-up when indoor temperature was near target. 
- Goal: make braking stateful and smooth so brakes ramp during real peaks (P80) and decay back toward zero when prices fall below P70, while protecting comfort.

### Description
- Added a new stateful helper `compute_brake_target` in `custom_components/svotc/control.py` that implements P80 enter / P70 exit hysteresis, returns a `BrakeDecision` with `target_offset`, `brake_active`, `in_peak`, `reason_code`, and `limited_by_comfort` flags, and accounts for a comfort guard cap. 
- Switched price classification in `custom_components/svotc/prices.py` to use the P80 percentile as the explicit expensive-enter threshold while keeping P30 for cheap and P70 for the exit band logic. 
- Updated `custom_components/svotc/coordinator.py` to use `compute_brake_target` and feed its `target_offset` into the existing `smooth_asymmetric` decay flow so offsets ramp up in peak and decay smoothly between peaks, added `_COMFORT_GUARD_MARGIN_C` and reused `last_applied_offset`/smoothed price offset to enforce comfort limiting, and exposed `p80` and new reason/status strings in attributes. 
- Introduced new reason/status codes `PRICE_BRAKE_ENTER`, `PRICE_BRAKE_HOLD`, `PRICE_BRAKE_DECAY` and ensured `PRICE_LIMITING_COMFORT` is only set when the comfort guard actively limits braking.

### Testing
- Added unit tests in `tests/test_control.py`: `test_brake_hysteresis_and_decay_between_peaks`, `test_brake_does_not_stick_at_p70`, and `test_comfort_guard_limits_brake_ramp` which exercise two-peak ramp/decay, P70 non-sticky behavior, and comfort guard limiting respectively. 
- Ran the test suite with `pytest -q` and all tests passed (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cc7aa555c832ea140a99eaa085c10)